### PR TITLE
fix/Ensure the `Content-Length` header is defined before using it

### DIFF
--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -95,7 +95,7 @@ sub make_request {
 
     $self->check_response_code($response->code);
 
-    if ($response->header('Content-Length') > 1) {
+    if ($response->header('Content-Length') && $response->header('Content-Length') > 1) {
         return xml_to_hash($response->content);
     } else {
         return {http_status => $response->code};

--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -95,7 +95,7 @@ sub make_request {
 
     $self->check_response_code($response->code);
 
-    if ($response->header('Content-Length') && $response->header('Content-Length') > 1) {
+    if ( $response->content || ( $response->header('Content-Length') && $response->header('Content-Length') > 1 ) ) {
         return xml_to_hash($response->content);
     } else {
         return {http_status => $response->code};

--- a/lib/WebService/Braintree/HTTP.pm
+++ b/lib/WebService/Braintree/HTTP.pm
@@ -95,7 +95,7 @@ sub make_request {
 
     $self->check_response_code($response->code);
 
-    if ( $response->content || ( $response->header('Content-Length') && $response->header('Content-Length') > 1 ) ) {
+    if ( $response->content || ( $response->header( 'Content-Length' ) && $response->header( 'Content-Length' ) > 1 ) ) {
         return xml_to_hash($response->content);
     } else {
         return {http_status => $response->code};


### PR DESCRIPTION
This PR modifies the WebService::Braintree::HTTP package to address the "Missing Content-Length Header" issue, which leads to the error `Use of uninitialized value in numeric gt (>)`. This error prevents the payment result response from PayPal from being processed, causing successful payments or sales to not be recorded in the DB. It also causing refund status from not being reflected correctly.

This update serves as a temporary fix for the [issues](https://github.com/Peatix/Product/issues/5048) related to PayPal payments and refunds. The long-term solution involves moving away from the WebService::Braintree package.
